### PR TITLE
Adding Electron Build Options

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,17 +7,26 @@
   "license": "MIT",
   "scripts": {
     "postinstall": "./utils/init.sh",
+    "clean": "rm -rf ./build",
     "build": "./utils/build.sh",
+    "build:web": "./utils/build.sh",
+    "build:win": "npm build; utils/electron/win.sh",
+    "build:osx": "npm build; utils/electron/osx.sh",
+    "build:linux": "npm build; utils/electron/linux.sh",
     "postversion": "git push origin v`npm view janusweb version`",
     "test": "./utils/activate.sh && ./node_modules/.bin/karma start tests/karma.conf.js --single-run"
   },
   "devDependencies": {
-    "karma": "~0.13",
+    "electron-build": "0.0.3",
+    "electron-builder": "^20.38.4",
+    "electron-packager": "^7.0.1",
+    "electron-prebuilt": "^1.4.13",
     "jasmine": ">=2.0",
     "jasmine-core": "*",
+    "karma": "~0.13",
+    "karma-chrome-launcher": "*",
     "karma-jasmine": "*",
-    "karma-jasmine-imagediff": "*",
-    "karma-chrome-launcher": "*"
+    "karma-jasmine-imagediff": "*"
   },
   "repository": {
     "type": "git",

--- a/scripts/electron/janusElectron.js
+++ b/scripts/electron/janusElectron.js
@@ -1,0 +1,72 @@
+const {app, BrowserWindow} = require('electron');
+const localShortcut = require('electron-localshortcut');
+
+const path = require('path')
+const url = require('url')
+
+// Keep a global reference of the window object, if you don't, the window will
+// be closed automatically when the JavaScript object is garbage collected.
+let januswebapp;
+
+function initJanusWeb() {
+  januswebapp = new JanusWebElectron();
+}
+
+function JanusWebElectron() {
+  this.windows = [];
+
+  this.windows.push(this.createWindow());
+
+
+}
+JanusWebElectron.prototype.createWindow = function() {
+  // Create the browser window.
+  var win = new BrowserWindow({
+    width: 1024,
+    height: 768,
+    title: 'JanusVR'
+  })
+  win.setFullScreen(true);
+  // and load the index.html of the app.
+  win.loadURL(url.format({
+    pathname: path.join(__dirname, 'index.html'),
+    protocol: 'file:',
+    slashes: true
+  }))
+
+  localShortcut.register(win, 'CmdOrCtrl+Shift+J', this.showDevTools.bind(this, win));
+  localShortcut.register(win, 'CmdOrCtrl+N', this.createWindow.bind(this));
+  localShortcut.register(win, 'CmdOrCtrl+W', this.closeWindow.bind(this, win));
+  return win;
+}
+JanusWebElectron.prototype.showDevTools = function(win) {
+  // Open the DevTools.
+  win.webContents.openDevTools()
+}
+JanusWebElectron.prototype.closeWindow = function(win) {
+  win.close();
+}
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.on('ready', initJanusWeb)
+
+// Quit when all windows are closed.
+app.on('window-all-closed', () => {
+  // On macOS it is common for applications and their menu bar
+  // to stay active until the user quits explicitly with Cmd + Q
+  if (process.platform !== 'darwin') {
+    app.quit()
+  }
+})
+
+app.on('activate', () => {
+  // On macOS it's common to re-create a window in the app when the
+  // dock icon is clicked and there are no other windows open.
+/*
+  if (win === null) {
+    createWindow()
+  }
+*/
+})

--- a/scripts/electron/package.json
+++ b/scripts/electron/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "JanusWeb-Electron",
+    "version": "0.1.0",
+    "main": "app.js",
+    "dependencies": {
+      "electron-localshortcut": "^1.1.1"
+    },
+    "devDependencies": {
+        "electron": "^4.0.4"
+    },    
+    "scripts": {
+      "start": "electron ."
+    }
+  }

--- a/utils/electron/linux.sh
+++ b/utils/electron/linux.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+NODEJS=`which nodejs`
+if [ -z "$NODEJS" ]; then
+  NODEJS=`which node`
+fi
+if [ -z "$NODEJS" ]; then
+  echo "ERROR - Can't find 'nodejs' or 'node' binary in path, exiting"
+  exit
+fi
+
+VERSION=$("$NODEJS" -pe "require('./package.json').version")
+ORIGINALROOT=$(pwd)
+BUILDROOT=$(pwd)/build
+BUILDDIR=${BUILDROOT}/${VERSION}
+PREPACKBUILDDIR=$BUILDROOT/linux-$VERSION
+
+cp $(pwd)/scripts/electron/janusElectron.js $BUILDDIR/app.js
+cp $(pwd)/scripts/electron/package.json $BUILDDIR/package.json
+
+cd ${BUILDDIR}
+
+npm install
+electron-builder \"${BUILDDIR}\" --platform=linux
+cp ${BUILDDIR}/dist ${PREPACKBUILDDIR}
+rm -rf ${BUILDDIR}/dist

--- a/utils/electron/osx.sh
+++ b/utils/electron/osx.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+NODEJS=`which nodejs`
+if [ -z "$NODEJS" ]; then
+  NODEJS=`which node`
+fi
+if [ -z "$NODEJS" ]; then
+  echo "ERROR - Can't find 'nodejs' or 'node' binary in path, exiting"
+  exit
+fi
+
+VERSION=$("$NODEJS" -pe "require('./package.json').version")
+ORIGINALROOT=$(pwd)
+BUILDROOT=$(pwd)/build
+BUILDDIR=${BUILDROOT}/${VERSION}
+PREPACKBUILDDIR=$BUILDROOT/osx-$VERSION
+
+cp $(pwd)/scripts/electron/janusElectron.js $BUILDDIR/app.js
+cp $(pwd)/scripts/electron/package.json $BUILDDIR/package.json
+
+cd ${BUILDDIR}
+
+npm install
+electron-builder \"${BUILDDIR}\" --platform=osx
+cp ${BUILDDIR}/dist ${PREPACKBUILDDIR}
+rm -rf ${BUILDDIR}/dist

--- a/utils/electron/win.sh
+++ b/utils/electron/win.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+NODEJS=`which nodejs`
+if [ -z "$NODEJS" ]; then
+  NODEJS=`which node`
+fi
+if [ -z "$NODEJS" ]; then
+  echo "ERROR - Can't find 'nodejs' or 'node' binary in path, exiting"
+  exit
+fi
+
+VERSION=$("$NODEJS" -pe "require('./package.json').version")
+ORIGINALROOT=$(pwd)
+BUILDROOT=$(pwd)/build
+BUILDDIR=${BUILDROOT}/${VERSION}
+PREPACKBUILDDIR=$BUILDROOT/win-$VERSION
+
+cp $(pwd)/scripts/electron/janusElectron.js $BUILDDIR/app.js
+cp $(pwd)/scripts/electron/package.json $BUILDDIR/package.json
+
+cd ${BUILDDIR}
+
+npm install
+electron-builder \"${BUILDDIR}\" --platform=win
+cp ${BUILDDIR}/dist ${PREPACKBUILDDIR}
+rm -rf ${BUILDDIR}/dist


### PR DESCRIPTION
Added the ability to build electron applications
The next step would be to add custom engine code to elation and custom janus-vr features like local profiles.

NOTE :: Experimental feature not optimised For user deployment as no --igonre statments have been added

to build run the normal build commands clean and build
followed by `npm run build:win` or the equivalent for your os