### PR TITLE
mention XR Fragment compliance

### DIFF
--- a/scripts/room.js
+++ b/scripts/room.js
@@ -301,6 +301,7 @@ elation.require([
           }
         }
       } else if (this.urlhash) {
+        // XR Fragments spec (Level1: URL) https://xrfragment.org/#teleport%20camera
         let obj = this.getObjectById(this.urlhash);
         if (obj) {
           obj.localToWorld(spawnpoint.position.set(0,0,0));


### PR DESCRIPTION
I've added this comment so that the XR Fragments spec can reference JanusWeb as an pioneer-adopter.
Interestingly enough, JanusWeb was already doing this before the XR Fragments spec existed :)
Nevertheless, a good excuse to promote/inspire other projects to use JanusWeb, or also deeplink their spatial content.