### PR TITLE
added discord-link + more backlinks to madjin awesome docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@
 
 ## Using
 
-There are pseveral different ways] to use JanusWeb, depending on how much control you want to 
+There are [several different ways](https://madjin.github.io/janus-guide/#/home/usecases) to use JanusWeb, depending on how much control you want to 
 have over the whole system.
 
 ### Use our viewer
@@ -214,6 +214,14 @@ than happy to help you through this (it's all very experimental right now!)
 If you need to load a specific version of JanusWeb, all previous versions are stores on the same server, and can be accessed by construction a URL of the form ```https://web.janusvr.com/<version>/```.  This is useful if you have a room which you know works with a specific version, which relies on features which have since been deprecated or changed, or to determine whether bugs have been introduced.  
 
 JanusWeb versions follow the [Semantic Versioning 2.0.0](http://semver.org/) spec, which follows the format ```<major>.<minor>.<patch>``` - for example, at the time of writing (March 2017) the current stable release is **1.0.15**.  So if you want to view this version, you could go to https://web.janusvr.com/1.0.15/ and if you wanted to pull this specific version into your page, you could do so with ```<script src="https://web.janusvr.com/1.0.15/janusweb.js"></script>```.  We also support aliases for the most current version - for instance, https://web.janusvr.com/1.0/ will always refer to the most recent 1.0 release, https://web.janusvr.com/0.9/ the final 0.9 release, etc.
+
+## Ecosystem
+
+> Visualisation of [hyperlinked Janus rooms across the web](https://panopticon.spyduck.net/) (snapshot)
+
+* [janus-server](https://github.com/janusvr/janus-server) multiuser presence layer
+* [janus-gateway](https://janus.conf.meetecho.com/) webrtc/voip-layer [docs](https://janus.conf.meetecho.com/)
+* [janusxr-cli](https://github.com/coderofsalvation/janusxr-cli) swiss army CLI knife for room health/preservation
 
 ## Contributing
 JanusWeb is open source, and we welcome any contributions!  Please do report bugs using GitHub Issues,


### PR DESCRIPTION
Trying to tighten the onboarding to discord/documention a bit:

* discord-link (is otherwise hidden in the janusvr.com vesta-page)
* SEO: more backlinks to madjin docs
* SEO: added more words like 'immersive web' and 'WebXR'