### PR TITLE
added support for microformats + added xrfragments translator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,44 +1,409 @@
 {
   "name": "janusweb",
   "version": "1.5.56",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "cyclone-physics": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/cyclone-physics/-/cyclone-physics-1.1.3.tgz",
-      "integrity": "sha512-aL1zbbA8+zxsv6iuSCiwi8J0Edm7PzE/sB2zDMD6NDdszt9uE8+I63dBLLn/HyKCScauXWAkg627UdAuyW03yA==",
-      "requires": {
+  "packages": {
+    "": {
+      "name": "janusweb",
+      "version": "1.5.56",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "elation-engine": ">=0.9.114",
+        "nodemon": "^3.1.11",
+        "uglify-js": "*"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/cyclone-physics": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/cyclone-physics/-/cyclone-physics-1.1.5.tgz",
+      "integrity": "sha512-dwQCjuq/aeXWZ2lCKCHcJYas6jmkwyuSedUYd5gbjJ7OoKZxVZuBVZwE7bS1NfhhFn+jkHdS6KwL3tZYVtOFyw==",
+      "license": "MIT",
+      "dependencies": {
         "elation": ">=2.0.0"
       }
     },
-    "elation": {
-      "version": "2.3.23",
-      "resolved": "https://registry.npmjs.org/elation/-/elation-2.3.23.tgz",
-      "integrity": "sha512-m/uWYMEUgqWFIxpa9I5LM1TUcKX6SZfxJ+i2/j9P0xdH82MgiRszercV7n6abxiXhiRb/ykulwjZAcU+J+Nm7Q=="
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
-    "elation-engine": {
-      "version": "0.9.120",
-      "resolved": "https://registry.npmjs.org/elation-engine/-/elation-engine-0.9.120.tgz",
-      "integrity": "sha512-LNaqG5dq6cs3FgaZhTdh7p9sN8xQ1O3767D4ANf9svBs2XO1GOreDKlyyhK/0VhDt9f3F+Ir6LIZljvliEd03A==",
-      "requires": {
+    "node_modules/elation": {
+      "version": "2.3.24",
+      "resolved": "https://registry.npmjs.org/elation/-/elation-2.3.24.tgz",
+      "integrity": "sha512-kcU1EghJPIeIH0ur7j0uPaRk0/yhFe5g/qjBE0hJTeAW8i0Y9XkRu7H2NxIZ240VFndz/BSR25yZZh53g68ZdQ==",
+      "license": "MIT"
+    },
+    "node_modules/elation-engine": {
+      "version": "0.9.127",
+      "resolved": "https://registry.npmjs.org/elation-engine/-/elation-engine-0.9.127.tgz",
+      "integrity": "sha512-KVrWRwhzSp3zN2WpSEJWkHDEfiYN8mZm89OdWiokg3/PaaZv3EbRwkV0s9E2+BQNVY75C+4CppEVhP462LmKXQ==",
+      "license": "MIT",
+      "dependencies": {
         "cyclone-physics": "*",
         "elation": ">=2.2.10",
         "elation-share": "*"
       }
     },
-    "elation-share": {
+    "node_modules/elation-share": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/elation-share/-/elation-share-1.0.9.tgz",
       "integrity": "sha512-N49KWmMfGNR3+z1hcE/w0OZPQK5TY6yEL5XN/vfjhMIrMpCp/FNY2OGfItvZ3L4KA/HyB+8GD7Am7B7STSvU+A==",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "elation": ">=2.0.0"
       }
     },
-    "uglify-js": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
-      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "license": "ISC"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nodemon": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.11.tgz",
+      "integrity": "sha512-is96t8F/1//UHAjNPHpbsNY46ELPpftGUoSVNXwUfMk/qdjSylYrWSu1XavVTBOn526kFiOR733ATgNBCQyH0g==",
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "license": "ISC",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.1.tgz",
+      "integrity": "sha512-y/2wiW+ceTYR2TSSptAhfnEtpLaQ4Ups5zrjB2d3kuVxHj16j/QJwPl5PvuGy9uARb39J0+iKxcRPvtpsx4A4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "license": "MIT"
     }
   }
 }

--- a/scripts/room.js
+++ b/scripts/room.js
@@ -3,10 +3,10 @@ elation.require([
      'engine.things.generic', 'engine.things.label', 'engine.things.skybox',
     'janusweb.object', 'janusweb.portal', 'janusweb.image', 'janusweb.video', 'janusweb.text', 'janusweb.janusparagraph',
     'janusweb.sound', 'janusweb.januslight', 'janusweb.janusparticle', 'janusweb.janusghost',
-    'janusweb.translators.bookmarks', 'janusweb.translators.reddit', 'janusweb.translators.error', 'janusweb.translators.blank', 'janusweb.translators.default', 'janusweb.translators.dat', 'janusweb.translators.janusvfs'
+    'janusweb.translators.bookmarks', 'janusweb.translators.reddit', 'janusweb.translators.error', 'janusweb.translators.blank', 'janusweb.translators.default', 'janusweb.translators.dat', 'janusweb.translators.janusvfs', 'janusweb.translators.xrfragments'
   ], function() {
   let roomTranslators = false;
-  function initRoomTranslators() {
+  function initRoomTranslators(room) {
     roomTranslators = {
       '^janus-vfs:': elation.janusweb.translators.janusvfs({janus: janus}),
       '^about:blank$': elation.janusweb.translators.blank({janus: janus}),
@@ -14,8 +14,9 @@ elation.require([
       '^dat:': elation.janusweb.translators.dat({janus: janus}),
       '^https?:\/\/(www\.)?reddit.com': elation.janusweb.translators.reddit({janus: janus}),
       '^error$': elation.janusweb.translators.error({janus: janus}),
+      '.*\.(gltf|glb|dae)$': elation.janusweb.translators.xrfragments({janus: janus}),
       '^default$': elation.janusweb.translators.default({janus: janus})
-    };
+    }
   }
   elation.component.add('engine.things.janusroom', function() {
     this.postinit = function() {
@@ -100,7 +101,7 @@ elation.require([
       });
 
       if (!roomTranslators) {
-        initRoomTranslators();
+        initRoomTranslators(this);
       }
 
       this.spawnpoint = new THREE.Object3D();
@@ -301,8 +302,8 @@ elation.require([
           }
         }
       } else if (this.urlhash) {
-        // XR Fragments spec (Level1: URL) https://xrfragment.org/#teleport%20camera
-        let obj = this.getObjectById(this.urlhash);
+        // XR Fragments deeplink spec (Level1: URL) https://xrfragment.org/#teleport%20camera
+        let obj = this.getObjectById(this.urlhash) || this.getObjectByDeepName(this.urlhash)
         if (obj) {
           obj.localToWorld(spawnpoint.position.set(0,0,0));
           spawnpoint.orientation.setFromRotationMatrix(obj.objects['3d'].matrixWorld.lookAt(spawnpoint.position, obj.localToWorld(V(0,0,-1)), obj.localToWorld(V(0,1,0).sub(spawnpoint.position))));
@@ -707,11 +708,22 @@ elation.require([
         }
       }));
     }
-    this.loadFromSource = function(sourcecode, baseurl) {
+    this.loadFromSource = async function(sourcecode, baseurl) {
       if (baseurl) {
         this.baseurl = baseurl;
       }
-      var source = this.parseSource(sourcecode);
+
+      var source
+      // scan sourcecode for non-JML microformats within translators 
+      for( m in roomTranslators ){
+        let rt = roomTranslators[m] 
+        if( rt.parseSource && rt.parseSource.regex ){
+          source = await rt.parseSource(sourcecode,this)
+          if( source ) break;
+        }
+      }
+      if( !source ) source = this.parseSource(sourcecode)
+
       if (source && source.source) {
         this.roomsrc = source.source;
         var datapath = elation.config.get('janusweb.datapath', '/media/janusweb');
@@ -1956,8 +1968,19 @@ elation.require([
 */
 
     }
-    this.getObjectById = function(js_id) {
-      return this.jsobjects[js_id];
+    this.getObjectByDeepName = function(name) {
+      if( !this.janus.currentroom ) return
+      let obj = this.janus.currentroom.objects['3d'].getObjectByName(name)
+      if( obj ){ // return polyglot THREE/janusweb object for convenience
+        return new Proxy(obj,{
+          set(me,k,v){ obj[k] = v; return true;    },
+          get(me,k){ 
+            if( k == 'objects' ) return { '3d': me }
+            return obj[k]; 
+          }
+        })
+      }
+      return obj
     }
     this.getObjectsByClassName = function(classname) {
       var objects = [];

--- a/scripts/translators/xrfragments.js
+++ b/scripts/translators/xrfragments.js
@@ -1,0 +1,93 @@
+elation.require([], function() {
+  elation.component.add('janusweb.translators.xrfragments', function() {
+    this.init = function() {
+      this.description = "this implements the https://xrfragment.org standard for immersive 3d file browsing"
+    }
+    this.exec = function(args) {
+      return new Promise(elation.bind(this, function(resolve, reject) {
+
+        var room = this.room = args.room;
+        this.setupEvents()
+
+        var datapath = elation.config.get('janusweb.datapath', '/media/janusweb');
+
+        var roomdata = {
+          assets: {
+            assetlist: [
+              {assettype: 'model', name: 'scene', src: args.url},
+            ]
+          },
+          room: {
+            pos: [0,0,0],
+            xdir: "1 0 0",
+            zdir: "0 0 1",
+          },
+          object: [
+            {id: 'scene', js_id: 0, pos: "0 0 0", xdir: "-1 0 0", zdir: "0 0 -1", lighting: "false"}
+          ],
+          link: []
+        };
+        resolve(roomdata);
+      }));
+    }
+
+    this.spawnUserAtFragment = function(source) {
+      // XR Fragments deeplink spec: explicit or default spawn
+      // https://xrfragment.org/#teleport%20camera
+      if( ! this.room.urlhash ) this.room.urlhash = 'spawn'
+      this.room.setPlayerPosition.apply(this.room)
+      console.log("[xrfragment] camera teleport")
+    }
+
+    this.setupEvents = function(){
+      elation.events.add(room._room, 'room_load_complete', this.spawnUserAtFragment.bind(this) )
+    }
+
+    // translate XR Fragments microformat into JML
+    this.parseSource = async function(sourcecode, room){
+      this.room = room
+      const isJML = /<fireboxroom>[\s\S]*?<\/fireboxroom>/si;
+      if( sourcecode.match(isJML) ) return // JML takes precedence over microformats 
+
+      // extract href/title value
+      let el = document.createElement("div")
+      el.innerHTML = sourcecode
+      const link = el.querySelector("link[as=spatial-entrypoint]")
+      if( !link ) return
+      const title = el.querySelector("title")
+      const href  = link.getAttribute("href")
+      if( !href ) return
+      console.log("[xrfragment] detected XRF microformat")
+      const hrefNoHash = href.replace(/#.*/,'')
+
+      // if microformat has xr fragment in URI, use it if room-url has no xr fragment 
+      if( href.match(/#/) && !room.urlhash ){
+        room.urlhash = href.replace(/.*#/,'')
+      }
+      // check if link exists
+      const hrefFull = hrefNoHash.match('://') ? hrefNoHash : String(room.baseurl+hrefNoHash)  
+      const exist    = await fetch( hrefFull ,{method:'HEAD'})
+      if( !exist.ok ) return console.warn(`[xrfragment] ${link.outerHTML} resolves to invalid url ${hrefFull}`)
+
+      // setup events
+      this.setupEvents()
+      // return JML
+      return room.parseSource(`
+        <title>${ title ? title.innerText.replace(/\n.*/g,'') : room.baseurl.split("/").pop() }</title>
+        <FireBoxRoom>
+            <Assets>
+              <assetobject id="scene" src="${hrefNoHash}"/>
+            </Assets>
+            <Room>
+              <object pos="0 0 0" collision_id="scene" id="scene" />
+            </Room>
+        </FireBoxRoom>
+      `)
+    }
+    // microformat heuristic (https://xrfragment.org/#XRF%20microformat)
+    // example: <link rel="alternate" as="spatial-entrypoint" src="https://foo.org/bar.glb"> 
+    this.parseSource.regex = /<link\s+[^>]*rel=['"]spatial-entrypoint['"][^>]*\/?>/si;
+
+  });
+});
+


### PR DESCRIPTION
* allow [translators to scan](https://github.com/jbaicoianu/janusweb/blob/f6482603bd3b8acc622f5a50ad3ce957a03129d0/scripts/room.js#L717) for HTML microformats
* added xrfragments translator (which scans for its HTML [XRF microformat](https://xrfragment.org/#XRF%20microformat) ) ([docs here](https://coderofsalvation.github.io/janus-guide/#/wiki/translators))
* deeplinking now also supports spawning to any objectname <b>inside 3D assets too</b> ([docs here](https://coderofsalvation.github.io/janus-guide/#/wiki/addressibility)
* xrfragments translator: surf 3D files directly (auto-wraps JML around a gltf-url e.g.)

As you can see, I'm updating the documentation from/with jin, by adding the following sections:

* https://coderofsalvation.github.io/janus-guide/#/wiki/translators
* https://coderofsalvation.github.io/janus-guide/#/wiki/polyglot-files
* https://coderofsalvation.github.io/janus-guide/#/wiki/addressibility

ps. this includes [this PR](https://github.com/jbaicoianu/janusweb/pull/281) which updates package-files, to fix outdated elation-engine and uglify-js (which otherwise breaks on modern `await`).

![janusweb_xrfragments](https://github.com/user-attachments/assets/ac55ed2d-dfd3-4160-a919-38418ee669be)

![janusweb_xrfragments_microformat](https://github.com/user-attachments/assets/a6e4aa55-b0ed-4ef0-80c0-34c610ad02ad)
