### PR TITLE
fix for quest devices

### DIFF
--- a/media/assets/webui/apps/navigation/navigation.js
+++ b/media/assets/webui/apps/navigation/navigation.js
@@ -408,6 +408,11 @@ elation.elements.define('janus.ui.urlbar', class extends elation.elements.ui.pan
     }
   }
   handleBlur(ev) {
+    // enter-key on Quest devices (onscreen keyboards) is not emitted (blur-event instead)
+    // https://developers.meta.com/horizon/documentation/web/webxr-keyboard/
+    if (navigator.userAgent.indexOf('OculusBrowser') != -1) {
+      this.handleAccept({altKey:true}) // get straight to it
+    }
     setTimeout(() => {
       this.suggestions.hide();
     }, 100);


### PR DESCRIPTION
not sure why but similar to their [webxr systemkeyboard](https://developers.meta.com/horizon/documentation/web/webxr-keyboard/) implementation, the horizon OS keyboard does not emit 'submit'/enter-events e.g.
Perhaps this default android behaviour these day, dunnow.
Anyways, quest users can now 'enter' an URL in janusweb