### PR TITLE
bugfix: handle relative urls

### DIFF
--- a/scripts/room.js
+++ b/scripts/room.js
@@ -569,12 +569,12 @@ elation.require([
       }
       var baseurl = baseurloverride;
       if (!baseurl) {
-        if (url && !this.baseurl) {
+        if (url && url.match("://") && !this.baseurl) {
           baseurl = url.split('/');
           if (baseurl.length > 3) baseurl.pop();
           baseurl = baseurl.join('/') + '/';
-          this.baseurl = baseurl;
         }
+        this.baseurl = baseurl || "";
       } else {
         this.baseurl = baseurl;
       }
@@ -592,7 +592,7 @@ elation.require([
       var fullurl = url;
       if (fullurl[0] == '/' && fullurl[1] != '/') fullurl = this.baseurl + fullurl;
       if (!fullurl.match(/^https?:/) && !fullurl.match(/^\/\//)) {
-        fullurl = self.location.origin + fullurl;
+        fullurl = self.location.origin + (fullurl[0] == '/' ? '' :'/') + fullurl;
       } else if (!fullurl.match(/^https?:\/\/(localhost|127\.0\.0\.1)/) && fullurl.indexOf(document.location.origin) != 0) {
         fullurl = proxyurl + fullurl;
       }


### PR DESCRIPTION
this patch will allow relative urls like:

```
<janus-viewer src="my/path/to/room.xml"/>

<janus-viewer src="/my/path/to/room.xml"/>
```

> previously this would resolve incorrect URLs ( `http://my/path/to/room.xml/my/path/to/room.xml` and `http://localhost:8080//my/path/to/room.xml`) since `room.js` would insist on setting `this.baseurl`.

also typing `/my/path/to/room.xml` in the webui URL-bar and `#janus.url=/my/path/to/room.xml` are now possible.

> defining relative urls in portals already worked, but this fix makes things a bit easier to test without typing the whole URL (especially on a VR headset).

I've tested with some rooms to see if there were any regressions, but did not find any.
Only question is: was there a deliberate reason for room.js to always consume absolute urls?