### PR TITLE
added peertube translator #2webui

### DIFF
--- a/scripts/room.js
+++ b/scripts/room.js
@@ -3,11 +3,12 @@ elation.require([
      'engine.things.generic', 'engine.things.label', 'engine.things.skybox',
     'janusweb.object', 'janusweb.portal', 'janusweb.image', 'janusweb.video', 'janusweb.text', 'janusweb.janusparagraph',
     'janusweb.sound', 'janusweb.januslight', 'janusweb.janusparticle', 'janusweb.janusghost',
-    'janusweb.translators.bookmarks', 'janusweb.translators.reddit', 'janusweb.translators.error', 'janusweb.translators.blank', 'janusweb.translators.default', 'janusweb.translators.dat', 'janusweb.translators.janusvfs', 'janusweb.translators.xrfragments'
+    'janusweb.translators.bookmarks', 'janusweb.translators.reddit', 'janusweb.translators.error', 'janusweb.translators.blank', 'janusweb.translators.default', 'janusweb.translators.dat', 'janusweb.translators.janusvfs', 'janusweb.translators.xrfragments', 'janusweb.translators.peertube'
   ], function() {
   let roomTranslators = false;
   function initRoomTranslators(room) {
     roomTranslators = {
+      '^peertube$': elation.janusweb.translators.peertube({janus: janus}),
       '^janus-vfs:': elation.janusweb.translators.janusvfs({janus: janus}),
       '^about:blank$': elation.janusweb.translators.blank({janus: janus}),
       '^bookmarks$': elation.janusweb.translators.bookmarks({janus: janus}),
@@ -15,7 +16,7 @@ elation.require([
       '^https?:\/\/(www\.)?reddit.com': elation.janusweb.translators.reddit({janus: janus}),
       '^error$': elation.janusweb.translators.error({janus: janus}),
       '.*\.(gltf|glb|dae)$': elation.janusweb.translators.xrfragments({janus: janus}),
-      '^default$': elation.janusweb.translators.default({janus: janus})
+      '^default$': elation.janusweb.translators.default({janus: janus}),
     }
   }
   elation.component.add('engine.things.janusroom', function() {

--- a/scripts/translators/peertube.js
+++ b/scripts/translators/peertube.js
@@ -1,0 +1,89 @@
+elation.require([], function() {
+  elation.component.add('janusweb.translators.peertube', function() {
+    this.init = function() {
+      this.description = "peertube website to 3D translator"
+    }
+    this.exec = function(args) {
+      return new Promise(elation.bind(this, function(resolve, reject) {
+
+        var room = this.room = args.room;
+
+        reject() // for now
+
+        this.setupEvents()
+        var datapath = elation.config.get('janusweb.datapath', '/media/janusweb');
+
+        var roomdata = {
+          assets: {
+            assetlist: [
+              // {assettype: 'model', name: 'scene', src: args.url},
+            ]
+          },
+          room: {
+            pos: [0,0,0],
+            xdir: "1 0 0",
+            zdir: "0 0 1",
+          },
+          object: [
+            // {id: 'scene', js_id: 0, pos: "0 0 0", xdir: "-1 0 0", zdir: "0 0 -1", lighting: "false"}
+          ],
+          link: []
+        };
+        resolve(roomdata);
+      }));
+    }
+
+    // translate XR Fragments microformat into JML
+    this.parseSource = async function(sourcecode, room){
+      this.room = room
+      const isJML = /<fireboxroom>[\s\S]*?<\/fireboxroom>/si;
+      const isPeertube         = /<meta\s+[^>]*property=['"]og:platform['"]\s+[^>]*content=['"]peertube['"][^>]*\/?>/si;
+      const isPeertubeVideo    = /<meta\s+[^>]*property=['"]og:type['"]\s+[^>]*content=['"]video['"][^>]*\/?>/si;
+      const isPeertubeInstance = /<meta\s+[^>]*property=['"]og:type['"]\s+[^>]*content=['"]website['"][^>]*\/?>/si;
+      const is = {
+        JML:              sourcecode.match(isJML),
+        peertube:         sourcecode.match(isPeertube),
+        peertubeVideo:    sourcecode.match(isPeertubeVideo),
+        peertubeInstance: sourcecode.match(isPeertubeInstance),
+      }
+      if( is.JML || !is.peertube ) return // JML takes precedence over microformats 
+      if( !is.peertubeVideo && !is.peertubeInstance ) return 
+      
+      // ok..peertube time: get domtree 
+      let el = document.createElement("div")
+      el.innerHTML = sourcecode
+
+      // try to fetch title + cover
+      const title = el.querySelector("title")
+      let logo    = el.querySelector("meta[property='og:image']")?.getAttribute("content")
+      logo        = logo ? logo : el.querySelector("meta[property='og:image:url']")?.getAttribute("content")
+
+      let url      = new URL( String(room.url) )
+      let instance = url?.origin
+      let search   = url?.search ? new URLSearchParams(url.search).get("search") : ""
+
+      // return JML
+      return room.parseSource(`
+        <title>${ title ? title.innerText.replace(/\n.*/g,'') : room.baseurl.split("/").pop() }</title>
+        <FireBoxRoom>
+            <Assets>
+              ${ logo ? `<assetimage src="${logo}" id="logo"/>` : ''}
+              <assetscript src="https://codeberg.org/coderofsalvation/janus-script-peertube/raw/branch/master/build/janus-script-peertube.js"/>
+              <assetobject src="https://codeberg.org/coderofsalvation/janus-script-peertube/raw/branch/master/build/asset/button.glb" id="button"/>
+              <assetobject src="https://codeberg.org/coderofsalvation/janus-script-peertube/raw/branch/master/build/asset/button.icon.glb"  id="icon"/>
+              <assetsound  src="https://codeberg.org/coderofsalvation/janus-script-peertube/raw/branch/master/build/asset/button.click.mp3" id="button-click"/>
+              <assetsound  src="https://codeberg.org/coderofsalvation/janus-script-peertube/raw/branch/master/build/asset/button.hover.mp3" id="button-hover"/>
+            </Assets>
+            <Room use_local_asset="room_2pedestal" pos="1.15 0 -5" rotation="0 1.5708 0" fwd="1 0 0">
+              ${ is.peertubeInstance ? `<peertube-app pos="4.55 2.71 -4.7" scale="2 2 1" rotation="0 90 0" js_id="mypeertube-app" instance="${instance}" ${search?`search="${search}"`:``} autoload="true"/>`
+                                     : `<peertube     pos="4.55 2.71 -4.7" scale="2 2 1" rotation="0 90 0" js_id="peertube" src="${room.url}" auto_play="true"/>` 
+               }
+              ${ logo ? `<image id="logo"/>` : ''}
+            </Room>
+        </FireBoxRoom>
+      `)
+    }
+    // peertube microformat heuristic: <meta property="og:platform" content="PeerTube">
+    this.parseSource.regex = /<meta\s+[^>]*property=['"]og:platform['"]\s+[^>]*content=['"]peertube['"][^>]*\/?>/si;
+  });
+});


### PR DESCRIPTION
this basically adds video- and livestreaming support for any ([~1677 selfhosted](https://instances.joinpeertube.org/instances)) peertube instances.
In a way, it reboots integration of **OPEN video-ecosystem** into the **OPEN** spatial web.

> What is Peertube? https://makertube.net/w/58UdeJ7NayzNSScpTE3YRa

Under the hood this translator uses https://codeberg.org/coderofsalvation/janus-script-peertube
I decided not to bloat this repository further, or burden it with maintenance of such particular translator.
The translator supports peertube URL-format (manually typed in the url-bar or via clicking a portal):

* https://makertube.net
* https://makertube.net/?search=game 
* https://makertube.net/w/qnVNkHWSmgUV6uSPKJUStr

It will only launch these URLs via the peertube-translator, when a peertube's heuristic (`<meta property="og:platform" content="peertube"/>`) is detected too.

<img width="1464" height="866" alt="image" src="https://github.com/user-attachments/assets/ab67c479-9ab2-4c5d-a60d-791792fa8992" />


https://github.com/user-attachments/assets/e55e417e-969f-4387-a030-8dd67851d4f7

