### PR TITLE
render links as usual text

### DIFF
--- a/scripts/janusparagraph.js
+++ b/scripts/janusparagraph.js
@@ -92,6 +92,8 @@ elation.require(['janusweb.janusbase'], function() {
       content = content.replace(/<img(.*?)>/g, "<img$1 />");
 
       var styletag = '<style>.paragraphcontainer { ' + basestyle + '} .br { height: 1em; } .hr { margin: .5em 0; border: 1px inset #ccc; height: 0px; }';
+      styletag    += 'a { color:unset; text-decoration: none; }' // dont confuse users with nonclickable links
+
       if (this.css) {
         styletag += this.css;
       }


### PR DESCRIPTION
The paragraphs of this screenshot was filled with blue links.
Perhaps its better to lower the expectations a bit, since they are not clickable.

<img width="869" height="732" alt="image" src="https://github.com/user-attachments/assets/7286b688-1240-4ac0-8e4f-304a217b9784" />
