### PR TITLE
added url(translator) support for <paragraph>

### DIFF
--- a/scripts/client.js
+++ b/scripts/client.js
@@ -152,6 +152,30 @@ elation.require(['elements.elements', 'elements', 'engine.engine', 'engine.asset
           }
         }
       });
+      this.initProxies()
+    }
+    initProxies() {
+      elation.engine.assets = new Proxy(elation.engine.assets,{
+        get(me,k){
+          if( k == "corsproxy" && me[k] ){
+            const p = elation.config.get("engine.assets.corsproxies")
+            if( ! p?.length ){ 
+              return me[k] // nothing to roundrobin
+            }else{ // roundrobin proxies
+              if( !p.index ) p.index = 0
+              const corsproxy = p[ p.index ]  
+              elation.config.set("engine.assets.corsproxy", corsproxy )
+              p.index = (p.index + 1) % p.length
+              return corsproxy
+            }
+          }
+          return me[k]
+        },
+        set(me,k,v){
+          me[k] = v
+          return true
+        }
+      })
     }
     initButtons() {
       this.sharebutton = elation.ui.button({classname: 'janusweb_sharing', label: 'Share'});

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -1,5 +1,16 @@
 elation.config.set('janusweb.network.host', 'wss://presence.janusxr.org:5567');        // Default presence server
-elation.config.set('engine.assets.corsproxy', 'https://p.janusxr.org/'); // CORS proxy URL
+
+proxies = [
+  'https://p.janusxr.org/',
+  'https://cors.xrforge.isvery.ninja/'
+]
+elation.config.set('engine.assets.corsproxy',   proxies[0]); // CORS proxy URL
+elation.config.set('engine.assets.corsproxies', []        ); // rotate **online** proxies only
+proxies.map( (url) => 
+  fetch(url,{method:'HEAD'})
+  .then( (res) => res.ok && elation.config.get("engine.assets.corsproxies").push(url) )
+)
+
 elation.config.set('engine.assets.workers', 'auto'); // Number of workers to use for asset parsing
 //elation.config.set('engine.assets.image.maxsize', 16384); 
 elation.config.set('engine.assets.image.anisotropy', 16); 

--- a/scripts/janusparagraph.js
+++ b/scripts/janusparagraph.js
@@ -92,6 +92,8 @@ elation.require(['janusweb.janusbase'], function() {
       content = content.replace(/<img(.*?)>/g, "<img$1 />");
 
       var styletag = '<style>.paragraphcontainer { ' + basestyle + '} .br { height: 1em; } .hr { margin: .5em 0; border: 1px inset #ccc; height: 0px; }';
+      styletag    += 'a { color:unset; text-decoration: none; }' // dont confuse users with nonclickable links
+
       if (this.css) {
         styletag += this.css;
       }

--- a/scripts/janusparagraph.js
+++ b/scripts/janusparagraph.js
@@ -1,3 +1,36 @@
+/*
+ * <paragraph> text-to-texture translator. The builtin XMLtranslator allows:
+ *
+ *  1. inline html             : <paragraph><![CDATA[ <b>hello world</b> ]]></paragraph>
+ *  2. inline html (partial)   : <paragraph selector="span"><![CDATA[ <b>hello <span>world</span></b> ]]></paragraph>
+ *  3. external url            : <paragraph url="https://janusxr.org"/>
+ *  4. external url (partials) : <paragraph url="https://janusxr.org" selector=".infoText"/>
+ *  5. janusroom container html: <paragraph selector=".someclass"/>
+ *  6. janusroom container xml : <paragraph selector="tag subtag title"/>
+ *  7. RSS                     : <paragraph url="https://my.org/foo.rss" selector="item description"/>
+ *  8. XML                     : <paragraph url="https://my.org/bar.xml" selector="title"/>
+ *  9. any data- or selector-format via 'paragraph_translator' event
+ *
+ *  EXAMPLE TRANSLATOR:
+ *
+ *     room.addEventListener("paragraph_translator", function(e){
+ *       const {translator,paragraph} = e.detail
+ *       // now you can override the default translator
+ *       translator.fetch       = async (url) => this.text = "a response"  // my custom fetch function
+ *       translator.translate = () => this.html = this.text                // my x2html translator
+ *     }
+ *
+ *  NOTES:
+ *  1. By default, selectors are done via `document.querySelectorAll`
+ *  2. in case of multiple results:
+ *    2.1 clicking the paragraph with cycle through them
+ *    2.2 setting cycle="2000" allows for (2sec per item) slideshows
+ *    2.3 setting `rooms.objects.myparagraph.index++` cycles to next item
+ *  3. width/height-attributes offers finer control of texture size
+ *  4. ttl-attributes allows finer control of webrequest-cache (default 2 mins)
+ *  5. setting `rooms.object.myparagraph.selector = "#section2"' allows for statemanagement
+ */
+
 elation.require(['janusweb.janusbase'], function() {
   elation.component.add('engine.things.janusparagraph', function() {
     this.postinit = function() {
@@ -18,8 +51,46 @@ elation.require(['janusweb.janusbase'], function() {
         shadow: { type: 'boolean', default: true, set: this.updateMaterial },
         shadow_receive: { type: 'boolean', default: true, set: this.updateMaterial, comment: 'Receive shadows from self and other objects' },
         shadow_cast: { type: 'boolean', default: true, set: this.updateMaterial, comment: 'Cast shadows onto self and other objects' },
+        url: { type: 'string', default: '', set: this.fetchSource },
+        selector: { type: 'string', default: '', set: this.updateHTML },
+        index: { type: 'integer', default: 0, set: this.updateHTML },
+        cycle: {type: 'integer', default: 0, set: this.updateHTML },
+        width: { type: 'integer', default: 1024 },  
+        height: { type: 'integer', default: 1024 }, 
+        ttl: { type: 'integer', default: 120000, comment: 'expire texture/html after ms (default:2 mins)' }, 
       });
     }
+
+    let XMLTranslator = this.translator = {
+      fetch: async function(uri){
+        if( !uri.match(/^http/) ) return // let other translate deal with it
+        const uriExFragment = String(uri).replace(/#.*/,'')
+        const finalUrl = `${elation.engine.assets.corsproxy||''}${uriExFragment||''}`
+        fetch( finalUrl )
+        .then( (res) => res.text() )
+        .then( (text) => this.text = text )
+      },
+      translate: function(){   // generic XML/RSS/HTML preprocessor [this.text to this.html]
+        if( !this.text ) return
+        this.html = this.text
+        if( this.selector && typeof this.index != 'undefined' ){
+          const type    = this.text.match(/<(rss|feed)/) ? "text/xml" : "text/html"
+          const parser  = new DOMParser()
+          const xmlDoc  = parser.parseFromString( this.text, type)
+          const partial = xmlDoc.querySelectorAll(this.selector) // KiSS JML: CSS selectors level 1
+          if( partial.length ){
+            this.indexes = partial.length > 1 ? partial.length : 1
+            this.html    = type == 'text/xml' 
+                         ? partial[ this.index % this.indexes ].textContent 
+                         : partial[ this.index % this.indexes ].outerHTML;
+            this.autoRotateIndex()
+          }else{ 
+            console.error(`paragraph: level1 css selector '${this.selector}' not matching anything`)
+          }
+        }
+      }
+    }
+
     this.createObject3D = function() {
       var material = this.createMaterial();
       var geo = new THREE.PlaneGeometry(2,2);
@@ -27,6 +98,9 @@ elation.require(['janusweb.janusbase'], function() {
       var mesh = new THREE.Mesh(geo, material);
       mesh.castShadow = this.shadow && this.shadow_cast;
       mesh.receiveShadow = this.shadow && this.shadow_receive;
+     
+      elation.events.add(this, 'click', elation.bind(this, () => this.indexes && (this.index++) ) )
+
       return mesh;
     }
     this.createForces = function() {
@@ -37,9 +111,9 @@ elation.require(['janusweb.janusbase'], function() {
     this.createMaterial = function() {
       var texture = this.createTexture();
       var sidemap = {
-        'back': THREE.FrontSide,
+        'back':  THREE.FrontSide,
         'front': THREE.BackSide,
-        'none': THREE.DoubleSide
+        'none':  THREE.DoubleSide
       };
       var matargs = {
         color: 0xffffff,
@@ -58,26 +132,28 @@ elation.require(['janusweb.janusbase'], function() {
     }
     this.createTexture = function() {
       this.canvas = document.createElement('canvas');
-      this.canvas.width = 1024;
-      this.canvas.height = 1024;
+      this.canvas.width = this.width;
+      this.canvas.height = this.height;
       this.texture = new THREE.Texture(this.canvas);
       this.texture.encoding = THREE.sRGBEncoding;
-      this.updateTexture();
+      if( this.text ) this.updateTexture();
       return this.texture;
     }
     this.updateTexture = function() {
       if (!this.canvas || !this.texture) return;
       var ctx = this.canvas.getContext('2d'),
           texture = this.texture;
-      this.canvas.width = 1024;
-      this.canvas.height = 1024;
+      this.canvas.width = this.width;
+      this.canvas.height = this.height;
+
       var text_col = '#' + this.text_col.getHexString(),
           back_col = 'rgba(' + (this.back_col.r * 255) + ', ' + (this.back_col.g * 255) + ', ' + (this.back_col.b * 255) + ', ' + this.back_alpha + ')';
       var basestyle = 'font-family: sans-serif;' +
                       'font-size: ' + this.font_size + 'px;' +
+                      'box-sizing: border-box;'  +
                       'color: ' + text_col + ';' +
                       'background: ' + (this.transparent ? 'transparent' : back_col) + ';' +
-                      'max-width: 1014px;' +
+                      `max-width: ${this.width}px;` +
                       'padding: 5px;';
 
       // We need to sanitize our HTML in case someone provides us with malformed markup.
@@ -92,6 +168,16 @@ elation.require(['janusweb.janusbase'], function() {
       content = content.replace(/<img(.*?)>/g, "<img$1 />");
 
       var styletag = '<style>.paragraphcontainer { ' + basestyle + '} .br { height: 1em; } .hr { margin: .5em 0; border: 1px inset #ccc; height: 0px; }';
+      styletag    += 'a { color:unset; text-decoration: none; }' // dont confuse users with nonclickable links
+
+      // hybrid 2D/3D styling: apply styles from container HTML if any
+      styletag += [ ...(new DOMParser)
+                       .parseFromString(room.fullsource,"text/html")
+                       .querySelectorAll("style[type=\"text/css\"]") 
+                  ]
+                  .map( (el) => el.innerText )
+                  .join("\n")
+
       if (this.css) {
         styletag += this.css;
       }
@@ -147,13 +233,24 @@ elation.require(['janusweb.janusbase'], function() {
           shadow: [ 'property', 'shadow' ],
           shadow_receive: [ 'property', 'shadow_receive' ],
           shadow_cast: [ 'property', 'shadow_cast' ],
+          url: [ 'property', 'url' ],
+          selector: [ 'property', 'selector' ],
+          index: ['property','index'],
+          cycle: ['property','cycle'],
+          width: ['property','width'],
+          height: ['property','height'],
+          ttl: ['property','ttl'],
         };
       }
       return this._proxyobject;
     }
 
     this.toInlineHTML = async function(){
-      this.html = this.text
+      // skip uninited url content
+      if( !this.text && this.url ) return 
+      if( this.text ) this.translator.translate.apply(this)
+      if( !this.html || this.htmlLast == this.html ) return // skip fake updates
+      this.htmlLast = this.html
       try{
         // find all img tags and capture src attributes
         const imgRegex = /<img[^>]*src=["'](?!data:)([^"']+)["']/gi;
@@ -174,16 +271,54 @@ elation.require(['janusweb.janusbase'], function() {
       this.updateTexture()
     };
 
-    this.toDataURL = function(url){
+    this.toDataURL = async function(url){
       const finalUrl = `${elation.engine.assets.corsproxy||''}${url}`
-      return fetch(finalUrl)
-      .then(response => response.blob())
-      .then(blob => new Promise((resolve, reject) => {
-        const reader = new FileReader()
-        reader.onloadend = () => resolve(reader.result)
-        reader.onerror = reject
-        reader.readAsDataURL(blob)
-      }))
+      return await this.useCache(url, async () => 
+        await fetch(finalUrl)
+        .then(response => response.blob())
+        .then(blob => new Promise((resolve, reject) => {
+          const reader = new FileReader()
+          reader.onloadend = () => resolve(reader.result)
+          reader.onerror = reject
+          reader.readAsDataURL(blob)
+        }))
+      )
+    }
+
+    this.fetchSource = async function(){
+      const t = this.translator = {...XMLTranslator}
+      if( !this.url ){
+        t.fetch = () => this.text = this.text || room.fullsource
+      }
+      // allow (via event) other scripts to select different translator based on url 
+      room.dispatchEvent({type:'paragraph_translator', detail:{ paragraph:this, translator: t} }) 
+      await t.fetch.call(this, this.url)
+    }
+
+    this.useCache = async function(url, myFetch) {
+      const cache = elation.janusweb.urlcache = elation.janusweb.urlcache || {}
+      if (cache[url]) return cache[url];
+      const data = cache[url] = await myFetch();
+      setTimeout(() => delete cache[url], this.ttl); // default 2 mins TTL cleanup
+      return data;
+    },
+
+    this.autoRotateIndex = function(){
+      if( this.cycle == 0 ){
+        clearInterval(this.intervalId )
+        this.intervalId = false
+      }
+      if( !this.intervalId && this.cycle ){
+        this.intervalId = setInterval( () => {
+          this.index = (this.index+1) % this.indexes 
+        }, this.cycle )
+      }
+    }
+
+    this.updateHTML = function(html){
+      if( this.html ){ 
+        this.toInlineHTML()
+      }
     }
 
   }, elation.engine.things.janusbase);

--- a/scripts/janusparagraph.js
+++ b/scripts/janusparagraph.js
@@ -36,7 +36,7 @@ elation.require(['janusweb.janusbase'], function() {
     this.postinit = function() {
       elation.engine.things.janusparagraph.extendclass.postinit.call(this);
       this.defineProperties({
-        text: {type: 'string', default: '', set: this.toInlineHTML },
+        text: {type: 'string', default: '', set: this.textToHTML },
         font_size: {type: 'integer', default: 16, set: this.updateTexture},
         text_col: {type: 'color', default: 0x000000, set: this.updateTexture},
         back_col: {type: 'color', default: 0xffffff, set: this.updateTexture},
@@ -68,15 +68,14 @@ elation.require(['janusweb.janusbase'], function() {
         const finalUrl = `${elation.engine.assets.corsproxy||''}${uriExFragment||''}`
         fetch( finalUrl )
         .then( (res) => res.text() )
-        .then( (text) => this.text = text )
+        .then( (text) => this.html = text )
       },
       translate: function(){   // generic XML/RSS/HTML preprocessor [this.text to this.html]
-        if( !this.text ) return
-        this.html = this.text
+        if( !this.html ) return
         if( this.selector && typeof this.index != 'undefined' ){
-          const type    = this.text.match(/<(rss|feed)/) ? "text/xml" : "text/html"
+          const type    = this.html.match(/<(rss|feed)/) ? "text/xml" : "text/html"
           const parser  = new DOMParser()
-          const xmlDoc  = parser.parseFromString( this.text, type)
+          const xmlDoc  = parser.parseFromString( this.html, type)
           const partial = xmlDoc.querySelectorAll(this.selector) // KiSS JML: CSS selectors level 1
           if( partial.length ){
             this.indexes = partial.length > 1 ? partial.length : 1
@@ -170,6 +169,8 @@ elation.require(['janusweb.janusbase'], function() {
       var styletag = '<style>.paragraphcontainer { ' + basestyle + '} .br { height: 1em; } .hr { margin: .5em 0; border: 1px inset #ccc; height: 0px; }';
       styletag    += 'a { color:unset; text-decoration: none; }' // dont confuse users with nonclickable links
 
+
+
       // hybrid 2D/3D styling: apply styles from container HTML if any
       styletag += [ ...(new DOMParser)
                        .parseFromString(room.fullsource,"text/html")
@@ -177,6 +178,7 @@ elation.require(['janusweb.janusbase'], function() {
                   ]
                   .map( (el) => el.innerText )
                   .join("\n")
+
 
       if (this.css) {
         styletag += this.css;
@@ -245,10 +247,16 @@ elation.require(['janusweb.janusbase'], function() {
       return this._proxyobject;
     }
 
+    this.textToHTML = function(){
+      if( this.html == this.text ) return
+      this.html = this.text
+      this.toInlineHTML()
+    }
+
     this.toInlineHTML = async function(){
       // skip uninited url content
-      if( !this.text && this.url ) return 
-      if( this.text ) this.translator.translate.apply(this)
+      if( !this.html && this.url ) return 
+      if( this.html ) this.translator.translate.apply(this)
       if( !this.html || this.htmlLast == this.html ) return // skip fake updates
       this.htmlLast = this.html
       try{
@@ -267,6 +275,7 @@ elation.require(['janusweb.janusbase'], function() {
           updatedHtml = updatedHtml.replace( `src="${src}"`, `src="${dataURLs[i]}"`)
         });
         this.html = updatedHtml
+        this.text = this.html
       }catch(e){ console.error(e) } // continue when inlining failed
       this.updateTexture()
     };
@@ -288,11 +297,12 @@ elation.require(['janusweb.janusbase'], function() {
     this.fetchSource = async function(){
       const t = this.translator = {...XMLTranslator}
       if( !this.url ){
-        t.fetch = () => this.text = this.text || room.fullsource
+        t.fetch = () => this.html = this.text || room.fullsource
       }
       // allow (via event) other scripts to select different translator based on url 
       room.dispatchEvent({type:'paragraph_translator', detail:{ paragraph:this, translator: t} }) 
       await t.fetch.call(this, this.url)
+      this.toInlineHTML()
     }
 
     this.useCache = async function(url, myFetch) {

--- a/scripts/room.js
+++ b/scripts/room.js
@@ -3,11 +3,12 @@ elation.require([
      'engine.things.generic', 'engine.things.label', 'engine.things.skybox',
     'janusweb.object', 'janusweb.portal', 'janusweb.image', 'janusweb.video', 'janusweb.text', 'janusweb.janusparagraph',
     'janusweb.sound', 'janusweb.januslight', 'janusweb.janusparticle', 'janusweb.janusghost',
-    'janusweb.translators.bookmarks', 'janusweb.translators.reddit', 'janusweb.translators.error', 'janusweb.translators.blank', 'janusweb.translators.default', 'janusweb.translators.dat', 'janusweb.translators.janusvfs', 'janusweb.translators.xrfragments'
+    'janusweb.translators.bookmarks', 'janusweb.translators.reddit', 'janusweb.translators.error', 'janusweb.translators.blank', 'janusweb.translators.default', 'janusweb.translators.dat', 'janusweb.translators.janusvfs', 'janusweb.translators.xrfragments', 'janusweb.translators.peertube'
   ], function() {
   let roomTranslators = false;
   function initRoomTranslators(room) {
     roomTranslators = {
+      '^peertube$': elation.janusweb.translators.peertube({janus: janus}),
       '^janus-vfs:': elation.janusweb.translators.janusvfs({janus: janus}),
       '^about:blank$': elation.janusweb.translators.blank({janus: janus}),
       '^bookmarks$': elation.janusweb.translators.bookmarks({janus: janus}),
@@ -15,7 +16,7 @@ elation.require([
       '^https?:\/\/(www\.)?reddit.com': elation.janusweb.translators.reddit({janus: janus}),
       '^error$': elation.janusweb.translators.error({janus: janus}),
       '.*\.(gltf|glb|dae)$': elation.janusweb.translators.xrfragments({janus: janus}),
-      '^default$': elation.janusweb.translators.default({janus: janus})
+      '^default$': elation.janusweb.translators.default({janus: janus}),
     }
   }
   elation.component.add('engine.things.janusroom', function() {


### PR DESCRIPTION
> Ok, honestly this is something I'm pretty excited about:

as discussed earlier, this adds (cached) url-support for `<paragraph>` via translators:

https://github.com/user-attachments/assets/a4959dd4-269a-4f77-a365-db2a8123bda9

> click [here for the JML-source of video](https://codeberg.org/coderofsalvation/janus-script-activitypub/src/branch/master/example.html)

First I had hardcoded HTML-urlsupport only..
But then I realized we might want to introduce the beloved 'translator'-concept here as well..
This maximizes the potential of pulling in content from various ecosystems/protocols.
Her's a demo of an custom translator: https://codeberg.org/coderofsalvation/janus-script-activitypub

`<paragraph>` comes with a default (XML) translator, so janusweb can handle RSS/XML/HTML urls out of the box.
It can also even translate itself! (`room.fullsource`)  

The source-header explains all the possibilities:

```
 * <paragraph> text-to-texture translator. The builtin XMLtranslator allows:                                                                            
 *                                                
 *  1. inline html             : <paragraph><![CDATA[ <b>hello world</b> ]]></paragraph>
 *  2. inline html (partial)   : <paragraph selector="span"><![CDATA[ <b>hello <span>world</span></b> ]]></paragraph>
 *  3. external url            : <paragraph url="https://janusxr.org"/>
 *  4. external url (partials) : <paragraph url="https://janusxr.org" selector=".infoText"/>
 *  5. janusroom container html: <paragraph selector=".someclass"/>
 *  6. janusroom container xml : <paragraph selector="tag subtag title"/>
 *  7. RSS                     : <paragraph url="https://my.org/foo.rss" selector="item description"/>
 *  8. XML                     : <paragraph url="https://my.org/bar.xml" selector="title"/>
 *  9. any data- or selector-format via 'paragraph_translator' event                             
 *                                                                                                
 *  NOTES:                               
 *  1. By default, selectors are done via `document.querySelectorAll`
 *  2. in case of multiple results:                   
 *    2.1 clicking the paragraph with cycle through them
 *    2.2 setting cycle="2000" allows for (2sec per item) slideshows                       
 *    2.3 setting `rooms.objects.myparagraph.index++` cycles to next item
 *  3. width/height-attributes offers finer control of texture size
 *  4. ttl-attributes allows finer control of webrequest-cache (default 2 mins)
 *  5. setting `rooms.object.myparagraph.selector = "#section2"' allows for statemanagement  
```

## custom translators

Whenever a `<paragraph>` fetch/renders itself, the room will emit an `paragraph_translator` event, with (a copy) of the default translator

```javascript
room.addEventListener("paragraph_translator", function(e){
  const {translator,paragraph} = e.detail
  // now you can override the default translator
  translator.fetch       = async (url) => this.text = "a response"  // my custom fetch function
  translator.translate = () => this.html = this.text                // my x2html translator
}
``` 