### PR TITLE
Parallax-corrected (box-projected) envmap reflections (opt-in per room)

### DIFF
--- a/scripts/object.js
+++ b/scripts/object.js
@@ -1105,18 +1105,62 @@ elation.require(['janusweb.janusbase', 'janusweb.websurface'], function() {
         }
         */
 
-        if (this.shader_chunk_replace) {
-          let chunkreplace = (elation.utils.isString(this.shader_chunk_replace) ? JSON.parse(this.shader_chunk_replace) : this.shader_chunk_replace);
+        let chunkreplace = (this.shader_chunk_replace ? (elation.utils.isString(this.shader_chunk_replace) ? JSON.parse(this.shader_chunk_replace) : this.shader_chunk_replace) : null);
+        // Parallax-corrected (box-projected) envmap reflections: opt-in per room via
+        // envmap_parallax + envmap_box_center/size. Anchors reflections to a box (e.g.
+        // the box bottom = floor) rather than the default infinite/camera-centered
+        // projection, so a reflective floor mirrors the walls at the right world
+        // position. Box uniforms are shared per-room objects, so live edits to the box
+        // update every reflection without a recompile. Default off => stock behavior.
+        let parallax = (this.isUsingPBR() && this.room && this.room.envmap_parallax) ? this.room.getEnvmapParallaxUniforms() : null;
+        if (parallax) this.registerParallaxChunk();
+        if (chunkreplace || parallax) {
           m.onBeforeCompile = function(shader) {
-            for (let oldchunkname in chunkreplace) {
-              let newchunkname = chunkreplace[oldchunkname];
-              shader.vertexShader = shader.vertexShader.replace('#include <' + oldchunkname + '>', '#include <' + newchunkname + '>');
-              shader.fragmentShader = shader.fragmentShader.replace('#include <' + oldchunkname + '>', '#include <' + newchunkname + '>');
+            if (chunkreplace) {
+              for (let oldchunkname in chunkreplace) {
+                let newchunkname = chunkreplace[oldchunkname];
+                shader.vertexShader = shader.vertexShader.replace('#include <' + oldchunkname + '>', '#include <' + newchunkname + '>');
+                shader.fragmentShader = shader.fragmentShader.replace('#include <' + oldchunkname + '>', '#include <' + newchunkname + '>');
+              }
+            }
+            if (parallax) {
+              shader.uniforms.boxProjMin = parallax.boxProjMin;
+              shader.uniforms.boxProjMax = parallax.boxProjMax;
+              shader.uniforms.boxProjCenter = parallax.boxProjCenter;
+              shader.vertexShader = 'varying vec3 vParallaxWorldPos;\n' + shader.vertexShader.replace(
+                '#include <project_vertex>',
+                '#include <project_vertex>\n\tvParallaxWorldPos = ( modelMatrix * vec4( transformed, 1.0 ) ).xyz;'
+              );
+              shader.fragmentShader = shader.fragmentShader.replace(
+                '#include <envmap_physical_pars_fragment>',
+                '#include <envmap_physical_pars_fragment_parallax>'
+              );
             }
           };
         }
       }
       return m;
+    }
+    this.registerParallaxChunk = function() {
+      // A box-projected variant of three's envmap_physical_pars_fragment: after the
+      // reflection vector is put into world space it's intersected with the box
+      // (boxProjMin..boxProjMax) and re-based on boxProjCenter, so the CubeUV/PMREM
+      // sample is parallax-corrected. Built by patching the stock chunk so it tracks
+      // the exact r150 source; if the source ever changes and the anchor line isn't
+      // found, this degrades to the stock (infinite) chunk rather than breaking.
+      if (THREE.ShaderChunk['envmap_physical_pars_fragment_parallax']) return;
+      let anchor = 'reflectVec = inverseTransformDirection( reflectVec, viewMatrix );';
+      let patched = THREE.ShaderChunk['envmap_physical_pars_fragment']
+        .replace('#if defined( USE_ENVMAP )',
+          '#if defined( USE_ENVMAP )\n\tuniform vec3 boxProjMin;\n\tuniform vec3 boxProjMax;\n\tuniform vec3 boxProjCenter;\n\tvarying vec3 vParallaxWorldPos;')
+        .replace(anchor, anchor +
+          '\n\t\t\t{ vec3 nrd = normalize( reflectVec );' +
+          '\n\t\t\t  vec3 rbmax = ( boxProjMax - vParallaxWorldPos ) / nrd;' +
+          '\n\t\t\t  vec3 rbmin = ( boxProjMin - vParallaxWorldPos ) / nrd;' +
+          '\n\t\t\t  vec3 rbmm = vec3( ( nrd.x > 0.0 ) ? rbmax.x : rbmin.x, ( nrd.y > 0.0 ) ? rbmax.y : rbmin.y, ( nrd.z > 0.0 ) ? rbmax.z : rbmin.z );' +
+          '\n\t\t\t  float fa = min( min( rbmm.x, rbmm.y ), rbmm.z );' +
+          '\n\t\t\t  reflectVec = ( vParallaxWorldPos + nrd * fa ) - boxProjCenter; }');
+      THREE.ShaderChunk['envmap_physical_pars_fragment_parallax'] = patched;
     }
     this.updateSkybox = function() {
       let envMap = (this.isUsingPBR() ? this.getEnvmap() : null);

--- a/scripts/room.js
+++ b/scripts/room.js
@@ -55,6 +55,13 @@ elation.require([
         'skybox_back_id': { type: 'string', set: this.setSkybox },
         'cubemap_irradiance_id': { type: 'string' },
         'cubemap_radiance_id': { type: 'string' },
+        // Envmap reflection projection. Default off = infinite (camera-centered)
+        // projection. When on, reflections are box-projected (parallax-corrected) to
+        // the box defined by envmap_box_center/size -- put the box bottom at the floor
+        // for clean floor reflections of the walls.
+        'envmap_parallax': { type: 'boolean', default: false, set: this.updateParallax },
+        'envmap_box_center': { type: 'vector3', default: new THREE.Vector3(0, 0, 0), set: this.updateParallax },
+        'envmap_box_size': { type: 'vector3', default: new THREE.Vector3(10, 10, 10), set: this.updateParallax },
         'fog': { type: 'boolean', default: false, set: this.setFog },
         'fog_mode': { type: 'string', default: 'exp', set: this.setFog },
         'fog_density': { type: 'float', default: 1.0, set: this.setFog },
@@ -325,6 +332,35 @@ elation.require([
         if( obj ) elation.events.fire({element: this, type: 'href', data: {href,opts}});
       }
       return spawnpoint;
+    }
+    // Shared box-projection uniforms for parallax-corrected envmap reflections. One
+    // set of THREE uniform objects per room; every PBR material's parallax shader
+    // references these same objects, so live edits to envmap_box_center/size update
+    // all reflections in place (no material recompile). See object.registerParallaxChunk.
+    this.getEnvmapParallaxUniforms = function() {
+      if (!this._parallaxUniforms) {
+        this._parallaxUniforms = {
+          boxProjMin: { value: new THREE.Vector3() },
+          boxProjMax: { value: new THREE.Vector3() },
+          boxProjCenter: { value: new THREE.Vector3() },
+        };
+      }
+      this.updateParallaxUniforms();
+      return this._parallaxUniforms;
+    }
+    this.updateParallaxUniforms = function() {
+      if (!this._parallaxUniforms) return;
+      let c = this.envmap_box_center || new THREE.Vector3();
+      let s = this.envmap_box_size || new THREE.Vector3(10, 10, 10);
+      this._parallaxUniforms.boxProjCenter.value.copy(c);
+      this._parallaxUniforms.boxProjMin.value.set(c.x - s.x / 2, c.y - s.y / 2, c.z - s.z / 2);
+      this._parallaxUniforms.boxProjMax.value.set(c.x + s.x / 2, c.y + s.y / 2, c.z + s.z / 2);
+    }
+    this.updateParallax = function() {
+      // Live box edits mutate the shared uniforms in place -> all reflections follow
+      // without a recompile. (Enabling/disabling envmap_parallax itself is applied at
+      // material-build time / room load.)
+      this.updateParallaxUniforms();
     }
     this.setSkybox = function() {
       if (!this.loaded) return;
@@ -1012,7 +1048,17 @@ elation.require([
 
         if (room.cubemap_radiance_id) this.properties.cubemap_radiance_id = room.cubemap_radiance_id;
         if (room.cubemap_irradiance_id) this.properties.cubemap_irradiance_id = room.cubemap_irradiance_id;
-    
+
+        let parseVec3 = (v) => {
+          if (v instanceof THREE.Vector3) return v;
+          if (typeof v == 'string') { let p = v.trim().split(/[\s,]+/).map(parseFloat); if (p.length >= 3 && p.every(n => !isNaN(n))) return new THREE.Vector3(p[0], p[1], p[2]); }
+          if (v && typeof v == 'object' && 'x' in v) return new THREE.Vector3(v.x, v.y, v.z);
+          return undefined;
+        };
+        if (typeof room.envmap_parallax != 'undefined') this.properties.envmap_parallax = (room.envmap_parallax === true || room.envmap_parallax === 'true');
+        let ebc = parseVec3(room.envmap_box_center); if (ebc) this.properties.envmap_box_center = ebc;
+        let ebs = parseVec3(room.envmap_box_size); if (ebs) this.properties.envmap_box_size = ebs;
+
         this.setSkybox();
 
         if (room.server) this.properties.server = room.server;
@@ -2225,6 +2271,9 @@ elation.require([
           skybox_down_id: ['property', 'skybox_down_id'],
           skybox_front_id:['property', 'skybox_front_id'],
           skybox_back_id: ['property', 'skybox_back_id'],
+          envmap_parallax: ['property', 'envmap_parallax'],
+          envmap_box_center: ['property', 'envmap_box_center'],
+          envmap_box_size: ['property', 'envmap_box_size'],
 
           pendingScripts: ['property', 'pendingScripts'],
           pendingCustomElements: ['property', 'pendingCustomElements'],

--- a/scripts/room.js
+++ b/scripts/room.js
@@ -1049,15 +1049,9 @@ elation.require([
         if (room.cubemap_radiance_id) this.properties.cubemap_radiance_id = room.cubemap_radiance_id;
         if (room.cubemap_irradiance_id) this.properties.cubemap_irradiance_id = room.cubemap_irradiance_id;
 
-        let parseVec3 = (v) => {
-          if (v instanceof THREE.Vector3) return v;
-          if (typeof v == 'string') { let p = v.trim().split(/[\s,]+/).map(parseFloat); if (p.length >= 3 && p.every(n => !isNaN(n))) return new THREE.Vector3(p[0], p[1], p[2]); }
-          if (v && typeof v == 'object' && 'x' in v) return new THREE.Vector3(v.x, v.y, v.z);
-          return undefined;
-        };
-        if (typeof room.envmap_parallax != 'undefined') this.properties.envmap_parallax = (room.envmap_parallax === true || room.envmap_parallax === 'true');
-        let ebc = parseVec3(room.envmap_box_center); if (ebc) this.properties.envmap_box_center = ebc;
-        let ebs = parseVec3(room.envmap_box_size); if (ebs) this.properties.envmap_box_size = ebs;
+        if (typeof room.envmap_parallax != 'undefined') this.envmap_parallax = room.envmap_parallax;
+        if (room.envmap_box_center) this.envmap_box_center = room.envmap_box_center;
+        if (room.envmap_box_size) this.envmap_box_size = room.envmap_box_size;
 
         this.setSkybox();
 


### PR DESCRIPTION
Adds an opt-in **parallax-corrected / box-projected** envmap reflection mode so reflective surfaces (a wet floor, polished ground) mirror the environment at the correct world position instead of the default infinite/camera-centered projection that slides with the camera. Put the box bottom at the floor for clean reflections of walls onto the ground.

## Room attributes (default off → stock infinite projection; existing rooms unchanged)
- `envmap_parallax` (bool) — enable box projection
- `envmap_box_center` (vec3), `envmap_box_size` (vec3) — the projection box; floor = box bottom (`center.y - size.y/2`)

Declared in the three canonical sites (schema / FireBoxRoom markup parse / scripting proxy) mirroring the skybox attributes. Box edits are live (shared uniforms mutated in place, no recompile).

## Shader
`object.registerParallaxChunk()` builds `envmap_physical_pars_fragment_parallax` by patching three r150's stock chunk — intersects the world-space `reflectVec` with the box and re-bases on `boxProjCenter` before the CubeUV/PMREM sample. `copyMaterial` attaches it through the existing `onBeforeCompile` hook when the room is PBR + `envmap_parallax`. No native three.js box-projection exists; this adapts the `webgl_materials_envmaps_parallax` technique to our equirect→PMREM pipeline.

## Verification
- Transform lands correctly in `getIBLRadiance`'s CubeUV branch (verified against the real r150 chunk).
- Patched `MeshPhysicalMaterial` + PMREM envMap **compiles + renders clean in headless WebGL** (0 GLSL/program errors).
- `npm run build` (1.7.2) succeeds; default-off path is byte-identical stock behavior.
- Remaining: in-room visual QA (reflection stays anchored to walls as the camera moves).