### PR TITLE
object: add sheen / sheen_color / sheen_roughness material attributes

### DIFF
--- a/scripts/object.js
+++ b/scripts/object.js
@@ -83,6 +83,9 @@ elation.require(['janusweb.janusbase', 'janusweb.websurface'], function() {
         emissive_intensity: { type: 'float', default: 1, set: this.updateMaterial, comment: 'Intensity of material emissive color' },
         roughness: { type: 'float', default: null, min: 0, max: 1, set: this.updateMaterial, comment: 'Material roughness value' },
         metalness: { type: 'float', default: null, set: this.updateMaterial, comment: 'Material metalness value' },
+        sheen: { type: 'float', default: null, min: 0, max: 1, set: this.updateMaterial, comment: 'Sheen intensity (velvet/fabric); MeshPhysicalMaterial only' },
+        sheen_color: { type: 'color', default: null, set: this.updateMaterial, comment: 'Sheen tint colour' },
+        sheen_roughness: { type: 'float', default: null, min: 0, max: 1, set: this.updateMaterial, comment: 'Sheen roughness' },
         transmission: { type: 'float', default: 0, set: this.updateMaterial, comment: 'Material transmission value' },
         usevertexcolors: { type: 'boolean', default: true, set: this.updateMaterial },
         gain: { type: 'float', default: 1.0, set: this.updateAudioNodes },
@@ -900,6 +903,17 @@ elation.require(['janusweb.janusbase', 'janusweb.websurface'], function() {
             }
             if (this.transmission !== null) {
               m.transmission = this.transmission;
+            }
+            // Sheen (velvet/fabric). MeshPhysicalMaterial only; m.sheen is undefined on other
+            // material types, so these are no-ops there. Attributes default to null (unset).
+            if (this.sheen !== null && m.sheen !== undefined) {
+              m.sheen = this.sheen;
+            }
+            if (this.sheen_roughness !== null && m.sheenRoughness !== undefined) {
+              m.sheenRoughness = this.sheen_roughness;
+            }
+            if (this.sheen_color && m.sheenColor) {
+              m.sheenColor.copy(this.sheen_color);
             }
 
             if (this.isUsingPBR() && !this.isUsingToonShader()) {


### PR DESCRIPTION
## What

Exposes MeshPhysicalMaterial's **sheen** as janus `<object>` material attributes, alongside the existing `roughness`/`metalness`:

- `sheen` (float 0..1) — sheen intensity (velvet/fabric look)
- `sheen_color` (color) — sheen tint
- `sheen_roughness` (float 0..1) — sheen roughness

Applied in `updateMaterial` next to `roughness`/`metalness`, guarded so they're **no-ops** unless set (`!== null`) and the material actually supports them (`m.sheen !== undefined` / `m.sheenColor`). PBR objects already build `MeshPhysicalMaterial` (`allocateMaterial`), so this just surfaces a capability that was there but unreachable from markup.

## Why

Needed a proper velvet look for the FIVARS Soul Symphony dome carpet — a lush deep-red velvet reads far better with real sheen than with albedo/roughness alone. Example:

```
<object id="carpet" image_id="rug_albedo" normalmap_id="rug_normal" roughness_id="rug_rough"
        metalness="0" roughness="1" sheen="1" sheen_color=".35 .05 .05" sheen_roughness=".5" />
```

## Notes

- Backward-compatible: attributes default to `null` (unset), so existing objects are unaffected.
- No sheen *map* attribute (uniform sheen only); can be added later if needed.