### PR TITLE
Add configurable panningmodel property to positional sounds

### DIFF
--- a/scripts/sound.js
+++ b/scripts/sound.js
@@ -16,6 +16,7 @@ elation.require(['janusweb.janusbase'], function() {
         gain: { type: 'float', default: 1.0, set: this.updateSound },
         starttime: { type: 'float', default: 0.0, set: this.updateSound },
         distancemodel: { type: 'string', default: 'inverse', set: this.updateSound },
+        panningmodel: { type: 'string', default: 'HRTF', set: this.updateSound },
         rolloff: { type: 'float', default: 1.0, set: this.updateSound },
         rect: { type: 'string', set: this.updateSound },
         stream: { type: 'boolean', default: false}
@@ -69,7 +70,7 @@ elation.require(['janusweb.janusbase'], function() {
           } else {
             //this.audio.panner.distanceModel = 'linear';
           }
-          this.audio.panner.panningModel = 'HRTF';
+          this.audio.panner.panningModel = this.properties.panningmodel || 'HRTF';
         }
         if (audionodes.gain) {
           // Route object's audio through the room's gain element
@@ -194,6 +195,7 @@ elation.require(['janusweb.janusbase'], function() {
           this.audio.setRolloffFactor(this.rolloff);
           this.audio.setRefDistance(this.dist);
           this.audio.setDistanceModel(this.distancemodel);
+          this.audio.panner.panningModel = this.panningmodel || 'HRTF';
         }
       }
       if (this.rect) {


### PR DESCRIPTION
## What

Positional sounds hard-coded `panner.panningModel = 'HRTF'`. This exposes it as a `panningmodel` property (default `'HRTF'`) and applies it both at creation and on live update.

## Why

Part of fixing muddy virtual-speaker surround output. When every channel of a 5.1 mix is fed through an HRTF panner, the center/dialogue channel picks up HRTF's direction-dependent notches in the 2–5 kHz speech-presence band and smears against the other correlated feeds. Being able to set a center virtual speaker to `equalpower` keeps dialogue crisp while the surrounds keep HRTF for 3D placement.

## Safety

Default is `'HRTF'`, so every existing sound is behaviorally unchanged — only a sound that explicitly opts into another model changes.

## Related

Enables the surround bass-management / center-clarity work in `janus-custom-components` (companion PR), whose `speaker` element sets `panningmodel: 'equalpower'` on the center channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)