### PR TITLE
Migrate to three.js r185

### DIFF
--- a/media/assets/webui/apps/editor/editor.js
+++ b/media/assets/webui/apps/editor/editor.js
@@ -198,8 +198,9 @@ this.outliner_hover.setLayers('10');
         this.roomedit.object.sync = true;
       });
     }
-    if (this.manipulator.parent != room._target.objects['3d']) {
-      room._target.objects['3d'].add(this.manipulator);
+    let manipulatorhelper = this.manipulator.getHelper();
+    if (manipulatorhelper.parent != room._target.objects['3d']) {
+      room._target.objects['3d'].add(manipulatorhelper);
       this.manipulator.enabled = false;
     }
     return this.manipulator;
@@ -230,7 +231,7 @@ this.outliner_hover.setLayers('10');
     } else {
       // non-transform property: park the gizmo and float a matching 3D UI if one is registered
       manipulator.enabled = false;
-      manipulator.visible = false;
+      manipulator.getHelper().visible = false;
       this.showPropertyUI(mode);
     }
     if (this.objectinfo) {
@@ -480,6 +481,7 @@ console.log('set translation snap', ev.data, ev);
     this.editObjectShowInfo(object);
     let manipulator = this.getManipulator();
     manipulator.attach(object.objects['3d']);
+    manipulator.getHelper().visible = true;
     // During raycast placement the gizmo stays visible but inert (no mouse
     // interaction); a normal edit makes it interactive.
     manipulator.enabled = !this.roomedit.raycast;
@@ -671,6 +673,7 @@ console.log('set translation snap', ev.data, ev);
     this.editObjectRemoveParentWireframe();
     let manipulator = this.getManipulator();
     manipulator.detach();
+    manipulator.getHelper().visible = false;
     manipulator.enabled = false;
     this.hidePropertyUI();
     if (this.objectinfo) {

--- a/scripts/image.js
+++ b/scripts/image.js
@@ -66,6 +66,11 @@ elation.require(['janusweb.janusbase'], function() {
           elation.events.add(this.asset, 'asset_load_progress', (ev) => { this.dispatchEvent({type: 'loadprogress', data: ev.data}); });
           elation.events.add(this.texture, 'asset_load', elation.bind(this, this.imageloaded));
           elation.events.add(this.texture, 'update', elation.bind(this, this.refresh));
+          // Some loaders (basis/ktx2) replace the asset's texture instance on
+          // load rather than mutating the placeholder we grabbed above, so the
+          // per-texture asset_load listener never fires. Re-check the instance
+          // on the asset-level load event and swap if it changed.
+          elation.events.add(this.asset, 'asset_load', elation.bind(this, this.setMaterialDirty));
 
           matargs.transparent = this.asset.hasalpha;
           elation.events.add(this.asset, 'asset_load', ev => {
@@ -156,8 +161,10 @@ elation.require(['janusweb.janusbase'], function() {
       setTimeout(() => {
         this.adjustAspectRatio();
       }, 0);
-      this.sidetex.image = this.texture.image;
-      this.sidetex.needsUpdate = true;
+      if (!this.texture.isCompressedTexture) {
+        this.sidetex.image = this.texture.image;
+        this.sidetex.needsUpdate = true;
+      }
 
       this.frontmaterial.transparent = this.asset.hasalpha;
       this.sidematerial.transparent = this.asset.hasalpha;

--- a/scripts/janusghost.js
+++ b/scripts/janusghost.js
@@ -347,9 +347,8 @@ elation.require(['janusweb.janusbase', 'engine.things.leapmotion'], function() {
           let rename = {};
           let bonemap = this.body.modelasset.vrm.humanoid.humanBones;
           for (let k in bonemap) {
-            console.log(k, bonemap[k]);
-            if (bonemap[k].length > 0) {
-              rename[bonemap[k][0].node.name] = k;
+            if (bonemap[k] && bonemap[k].node) {
+              rename[bonemap[k].node.name] = k;
             }
           }
           let bones = [];
@@ -380,10 +379,10 @@ elation.require(['janusweb.janusbase', 'engine.things.leapmotion'], function() {
           let parts = track.name.split('.');
           console.log(parts, track.name);
           try {
-            let bone = vrm.humanoid.getBone(parts[0]);
+            let bone = vrm.humanoid.getRawBoneNode(parts[0]);
             if (bone) {
-              track.name = bone.node.name + '.' + parts[1];
-              let sourcebone = sourcemesh.skeleton.getBone(bone.node.name);
+              track.name = bone.name + '.' + parts[1];
+              let sourcebone = sourcemesh.skeleton.getBoneByName(bone.name);
               //console.log(track, bone);
             } else {
               //console.log('no bone!', parts, track);

--- a/scripts/januslight.js
+++ b/scripts/januslight.js
@@ -113,7 +113,7 @@ elation.require(['janusweb.janusbase'], function() {
       if (this.light_style != '') {
         let idx = Math.floor(Date.now() / (1000 / this.light_style_fps)) % this.light_style.length;
         let brightness = (this.light_style.charCodeAt(idx) - 97) / 13;
-        this.light.intensity = .1 * brightness;
+        this.light.intensity = (this.baseintensity !== undefined ? this.baseintensity : .1 * Math.PI) * brightness;
       }
     }
     this.createLight = function() {
@@ -138,11 +138,15 @@ elation.require(['janusweb.janusbase'], function() {
         if (this.light.parent !== this.objects['3d']) {
           this.objects['3d'].add(this.light);
         }
-        //this.light.intensity = this.light_intensity / 100;
         var avgscale = (this.scale.x + this.scale.y + this.scale.z) / 3;
-        //this.light.intensity = this.light_intensity / 100;
-        let brightness = 1;
-        this.light.intensity = .1;
+        // Brightness lives entirely in intensity; color stays normalized. The
+        // shader result (color * intensity) is identical to the old approach of
+        // oversaturating the color, but this keeps light.color meaningful for
+        // helpers, editors, and scripts. The .1 factor is the historical Janus
+        // brightness calibration; x PI bridges the r165 removal of legacy
+        // (non-physical) light mode.
+        this.baseintensity = .1 * Math.PI * this.light_intensity * avgscale * avgscale;
+        this.light.intensity = this.baseintensity;
         this.light.penumbra = this.light_penumbra;
         this.light.decay = this.light_decay;
         if (this.color_temperature) {
@@ -150,7 +154,6 @@ elation.require(['janusweb.janusbase'], function() {
         } else {
           this.light.color.copy(this.color);
         }
-        this.light.color.multiplyScalar(this.light_intensity * avgscale * avgscale);
         this.light.distance = this.light_range * avgscale;
         if (this.light_cone_angle > 0 && this.light_cone_angle < 1) {
           this.light.angle = Math.acos(this.light_cone_angle);

--- a/scripts/janusparagraph.js
+++ b/scripts/janusparagraph.js
@@ -128,7 +128,7 @@ elation.require(['janusweb.janusbase','janusweb.translators.paragraph.html-xml-r
       this.canvas.width = this.width;
       this.canvas.height = this.height;
       this.texture = new THREE.Texture(this.canvas);
-      this.texture.encoding = THREE.sRGBEncoding;
+      this.texture.colorSpace = THREE.SRGBColorSpace;
       if( this.text ) this.updateTexture();
       return this.texture;
     }

--- a/scripts/janusxrplayer.js
+++ b/scripts/janusxrplayer.js
@@ -919,6 +919,7 @@ elation.require(['engine.things.generic', 'janusweb.external.webxr-input-profile
           jointposes[jointname] = jointpose;
         }
         this.joints.instanceMatrix.needsUpdate = true;
+        this.joints.computeBoundingSphere(); // r151+: InstancedMesh is frustum-culled by default and needs a valid bounds after matrix updates
         //this.joints.computeBoundingSphere();
 
         if (jointposes['wrist']) this.localToWorld(this.handpos.copy(this.jointposes['wrist'].transform.position));

--- a/scripts/object.js
+++ b/scripts/object.js
@@ -751,7 +751,7 @@ elation.require(['janusweb.janusbase', 'janusweb.websurface'], function() {
             if (texture) {
               //if (!color) m.color.setHex(0xffffff);
               m.map = texture;
-              texture.encoding = THREE.sRGBEncoding;
+              texture.colorSpace = THREE.SRGBColorSpace;
               if (false && !this.assetloadhandlers[texture.uuid]) {
                 this.assetloadhandlers[texture.uuid] = true;
                 elation.events.add(texture, 'asset_update', (ev) => {
@@ -771,7 +771,7 @@ elation.require(['janusweb.janusbase', 'janusweb.websurface'], function() {
                   m.alphaTest = this.alphatest;
                 }
                 m.map = asset.getInstance();
-                m.map.encoding = THREE.sRGBEncoding;
+                m.map.colorSpace = THREE.SRGBColorSpace;
                 if (!this.assetloadhandlers[m.map.uuid]) {
                   this.assetloadhandlers[m.map.uuid] = true;
                   elation.events.add(m.map, 'asset_update', elation.bind(this, function(ev) {
@@ -846,21 +846,33 @@ elation.require(['janusweb.janusbase', 'janusweb.websurface'], function() {
 
             if (textureLightmap && textureLightmap.image) {
               if (lightmaptextureasset.loaded) {
-                m.lightMap = textureLightmap; 
+                m.lightMap = textureLightmap;
+                m.lightMap.channel = 1;
+                m.lightMapIntensity = Math.PI; // r165 removed legacy mode's internal xPI on lightmap irradiance // lightmaps use the second UV set (pre-r152 'uv2', now 'uv1')
+                m.lightMap.colorSpace = THREE.NoColorSpace; m.lightMap.needsUpdate = true; // legacy lightmaps multiply in display space, sample raw like r150 did
                 if (!this.assetloadhandlers[m.lightMap.uuid]) {
                   this.assetloadhandlers[m.lightMap.uuid] = true;
-                  elation.events.add(textureLightmap, 'asset_update', elation.bind(m, function(ev) { m.lightMap = ev.data; this.refresh(); }));
+                  elation.events.add(textureLightmap, 'asset_update', elation.bind(m, function(ev) { m.lightMap = ev.data; m.lightMap.channel = 1; m.lightMap.colorSpace = THREE.NoColorSpace; m.lightMap.needsUpdate = true; m.lightMapIntensity = Math.PI; this.refresh(); }));
                 }
               }
             } else if (m.lightMap) {
               var imagesrc = m.lightMap.sourceFile;
+              // material-level legacy bridges, applied unconditionally: several
+              // materials can share one lightmap texture, and the uuid guard
+              // below only dedupes the texture-level handler registration
+              m.lightMap.channel = 1; // lightmaps use the second UV set (pre-r152 'uv2', now 'uv1')
+              m.lightMap.colorSpace = THREE.NoColorSpace; m.lightMap.needsUpdate = true; // legacy lightmaps multiply in display space, sample raw like r150 did
+              m.lightMapIntensity = Math.PI; // r165 removed legacy mode's internal xPI on lightmap irradiance
               if (!this.assetloadhandlers[m.lightMap.uuid]) {
                 this.assetloadhandlers[m.lightMap.uuid] = true;
-                var asset = this.getAsset('image', imagesrc, {id: imagesrc, src: imagesrc, hasalpha: false});
+                var asset = this.getAsset('image', imagesrc, {id: imagesrc, src: imagesrc, hasalpha: false, srgb: false});
                 if (asset) {
                   m.lightMap = asset.getInstance();
-                  elation.events.add(asset, 'asset_load', elation.bind(this, function(ev) { m.lightMap = ev.data; this.refresh();}));
-                  elation.events.add(m.lightMap, 'asset_update', elation.bind(this, function(ev) { m.lightMap = ev.data; this.refresh(); }));
+                  m.lightMap.channel = 1;
+                  m.lightMapIntensity = Math.PI; // r165 removed legacy mode's internal xPI on lightmap irradiance // lightmaps use the second UV set (pre-r152 'uv2', now 'uv1')
+                  m.lightMap.colorSpace = THREE.NoColorSpace; m.lightMap.needsUpdate = true; // legacy lightmaps multiply in display space, sample raw like r150 did
+                  elation.events.add(asset, 'asset_load', elation.bind(this, function(ev) { m.lightMap = ev.data; m.lightMap.channel = 1; m.lightMap.colorSpace = THREE.NoColorSpace; m.lightMap.needsUpdate = true; m.lightMapIntensity = Math.PI; this.refresh();}));
+                  elation.events.add(m.lightMap, 'asset_update', elation.bind(this, function(ev) { m.lightMap = ev.data; m.lightMap.channel = 1; m.lightMap.colorSpace = THREE.NoColorSpace; m.lightMap.needsUpdate = true; m.lightMapIntensity = Math.PI; this.refresh(); }));
                 }
               }
             }
@@ -871,10 +883,10 @@ elation.require(['janusweb.janusbase', 'janusweb.websurface'], function() {
             if (this.lighting) {
               if (textureEmissive) {
                 m.emissiveMap = textureEmissive;
-                textureEmissive.encoding = THREE.sRGBEncoding;
+                textureEmissive.colorSpace = THREE.SRGBColorSpace;
                 m.emissive = new THREE.Color(0xffffff);
               } else if (m.emissiveMap) {
-                m.emissiveMap.encoding = THREE.sRGBEncoding;
+                m.emissiveMap.colorSpace = THREE.SRGBColorSpace;
               } else if (this.emissive) {
                 //m.emissive = this.emissive.clone();
                 m.emissive.copy(this.emissive)
@@ -883,7 +895,7 @@ elation.require(['janusweb.janusbase', 'janusweb.websurface'], function() {
             } else {
               if (textureEmissive) {
                 m.map = textureEmissive;
-                textureEmissive.encoding = THREE.sRGBEncoding;
+                textureEmissive.colorSpace = THREE.SRGBColorSpace;
                 m.color = new THREE.Color(0xffffff);
               }
             }
@@ -977,7 +989,6 @@ elation.require(['janusweb.janusbase', 'janusweb.websurface'], function() {
               }
             }
             //m.needsUpdate = true;
-            m.skinning = useSkinning;
             if (useVertexColors) {
               m.vertexColors = true;
             } else {
@@ -985,6 +996,13 @@ elation.require(['janusweb.janusbase', 'janusweb.websurface'], function() {
             }
             if (!(m instanceof THREE.ShaderMaterial)) {
               m.fog = this.fog;
+            }
+            if (m.isMeshPhongMaterial && m.shininess < .01) {
+              // Exporters (especially Collada) emit shininess 0, which makes the
+              // blinn-phong term pow(0, 0) = NaN on silhouette pixels - visible
+              // as black/white speckles in the HDR pipeline. An epsilon floor is
+              // visually identical.
+              m.shininess = .01;
             }
             m.wireframe = this.wireframe;
           }
@@ -1075,7 +1093,6 @@ elation.require(['janusweb.janusbase', 'janusweb.websurface'], function() {
         m.transmissionMap = oldmat.transmissionMap;
         m.transparent = oldmat.transparent || m.opacity < 1;
         m.alphaTest = oldmat.alphaTest;
-        m.skinning = oldmat.skinning;
 
         if (oldmat.metalness !== undefined) m.metalness = oldmat.metalness;
         if (oldmat.metalnessMap !== undefined) m.metalnessMap = oldmat.metalnessMap;
@@ -1160,13 +1177,13 @@ elation.require(['janusweb.janusbase', 'janusweb.websurface'], function() {
       // reflection vector is put into world space it's intersected with the box
       // (boxProjMin..boxProjMax) and re-based on boxProjCenter, so the CubeUV/PMREM
       // sample is parallax-corrected. Built by patching the stock chunk so it tracks
-      // the exact r150 source; if the source ever changes and the anchor line isn't
+      // the exact r185 source; if the source ever changes and the anchor line isn't
       // found, this degrades to the stock (infinite) chunk rather than breaking.
       if (THREE.ShaderChunk['envmap_physical_pars_fragment_parallax']) return;
-      let anchor = 'reflectVec = inverseTransformDirection( reflectVec, viewMatrix );';
+      let anchor = 'reflectVec = transformDirectionByInverseViewMatrix( reflectVec, viewMatrix );';
       let patched = THREE.ShaderChunk['envmap_physical_pars_fragment']
-        .replace('#if defined( USE_ENVMAP )',
-          '#if defined( USE_ENVMAP )\n\tuniform vec3 boxProjMin;\n\tuniform vec3 boxProjMax;\n\tuniform vec3 boxProjCenter;\n\tvarying vec3 vParallaxWorldPos;')
+        .replace('#ifdef USE_ENVMAP',
+          '#ifdef USE_ENVMAP\n\tuniform vec3 boxProjMin;\n\tuniform vec3 boxProjMax;\n\tuniform vec3 boxProjCenter;\n\tvarying vec3 vParallaxWorldPos;')
         .replace(anchor, anchor +
           '\n\t\t\t{ vec3 nrd = normalize( reflectVec );' +
           '\n\t\t\t  vec3 rbmax = ( boxProjMax - vParallaxWorldPos ) / nrd;' +

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -126,7 +126,7 @@ elation.require(['janusweb.janusbase'], function() {
         var asset = this.getAsset('image', this.thumb_id);
         if (asset) var thumb = asset.getInstance();
         if (thumb) {
-          thumb.encoding = THREE.sRGBEncoding;
+          thumb.colorSpace = THREE.SRGBColorSpace;
           if (shader) {
             mat.uniforms.iChannel0.value = thumb;
           } else {

--- a/scripts/room.js
+++ b/scripts/room.js
@@ -30,9 +30,11 @@ elation.require([
         'none': THREE.NoToneMapping,
         'linear': THREE.LinearToneMapping,
         'reinhard': THREE.ReinhardToneMapping,
-        'uncharted2': THREE.Uncharted2ToneMapping,
+        'uncharted2': THREE.CineonToneMapping, // Uncharted2 removed upstream; Cineon is the closest filmic curve
         'cineon': THREE.CineonToneMapping,
         'acesfilmic': THREE.ACESFilmicToneMapping,
+        'agx': THREE.AgXToneMapping,
+        'neutral': THREE.NeutralToneMapping,
       };
       this.defineProperties({
         'janus': { type: 'object' },
@@ -390,7 +392,7 @@ elation.require([
         if (equi.loaded) {
           this.skyboxtexture = equi.getInstance();
           this.skyboxtexture.mapping = THREE.EquirectangularReflectionMapping;
-          this.skyboxtexture.encoding = THREE.sRGBEncoding;
+          this.skyboxtexture.colorSpace = THREE.SRGBColorSpace;
           if (this.janus.currentroom === this) {
             this.skyboxobj.setTexture(this.skyboxtexture);
           }
@@ -399,7 +401,7 @@ elation.require([
           elation.events.add(equi, 'asset_load', ev => {
             this.skyboxtexture = ev.target._texture;
             this.skyboxtexture.mapping = THREE.EquirectangularReflectionMapping;
-            this.skyboxtexture.encoding = THREE.sRGBEncoding;
+            this.skyboxtexture.colorSpace = THREE.SRGBColorSpace;
             if (this.janus.currentroom === this) {
               this.skyboxobj.setTexture(this.skyboxtexture);
             }
@@ -504,7 +506,7 @@ elation.require([
           // flip skybox 180 degrees
           images = [images[1],images[0],images[2],images[3],images[5],images[4]];
           var texture = new THREE.CubeTexture( images );
-          texture.encoding = THREE.sRGBEncoding;
+          texture.colorSpace = THREE.SRGBColorSpace;
           texture.needsUpdate = true;
           this.skyboxtexture = texture;
           if (this.janus.currentroom === this) {

--- a/scripts/text.js
+++ b/scripts/text.js
@@ -139,7 +139,7 @@ elation.require(['engine.things.label'], function() {
 
       var geometry = new THREE.TextGeometry( text, {
         size: this.font_size,
-        height: this.properties.thickness || this.font_size / 8,
+        depth: this.properties.thickness || this.font_size / 8,
         curveSegments: this.segments,
 
         font: font,

--- a/scripts/video.js
+++ b/scripts/video.js
@@ -64,7 +64,6 @@ elation.require(['janusweb.janusbase'], function() {
 
       this.texture.minFilter = THREE.LinearFilter;
       this.texture.magFilter = THREE.LinearFilter;
-      this.texture.format = THREE.RGBFormat;
       this.texture.generateMipmaps = false;
 
       var matargs = {


### PR DESCRIPTION
App-side migration to three r185, companion to jbaicoianu/elation-engine#25 (which carries the ESM prebundle pipeline and regenerated addon bundles this depends on).

## Highlights
- **Lightmaps**: r152 decoupled `lightMap` from the implicit uv2 attribute — without `texture.channel = 1` every .dae lightmap smeared through the diffuse UVs. They also now sample raw display-space values like r150 (with a forced re-upload to beat a texture-upload race) at `lightMapIntensity = π` per the r165 legacy-lights migration. Verified pixel-level against live web.janusxr.org (within ~8%).
- **Color**: encoding→colorSpace renames; AgX/Neutral added to the room tonemapping map.
- **Lighting**: januslight brightness moved from oversaturated color into `intensity` (identical shader product, meaningful `light.color` for helpers/editors/scripts), ×π-bridged for r165.
- **Text**: TextGeometry `height`→`depth` (r163) — was silently rendering flat.
- **Editor**: TransformControls scene presence and visibility via `getHelper()` (r169 refactor).
- **Images**: asset-level reload hook fixes .basis texture display (the actual bug behind Basis support being disabled in 2025); VRM ghost retargeting ported to three-vrm 3.x; XR hand joints get bounds recomputed for r151's InstancedMesh culling default.

## Verification
Headless-browser tested: default world, a basis/text test room, and the janusxr.org lobby compared against the live r150 deployment (pixel probes at fixed coordinates, material/texture state diffs, and measured transfer curves — the r150 pipeline's net response is exactly one sRGB conversion, which OutputPass reproduces).

Known deferred item: grazing-angle specular flashes on double-sided PBR foliage cards (GGX behavior, more visible under physical lighting — discussed options: shader-level firefly clamp via the engine patch file, or fixing the lobby's leaf materials).