### PR TITLE
object: stop setting material.anisotropy on cloned materials

### DIFF
--- a/scripts/object.js
+++ b/scripts/object.js
@@ -1055,7 +1055,6 @@ elation.require(['janusweb.janusbase', 'janusweb.websurface'], function() {
       } else {
         var m = this.allocateMaterial();
         m.dithering = true;
-        m.anisotropy = 16;
         m.name = oldmat.name;
         m.map = oldmat.map;
         m.cloned = true;


### PR DESCRIPTION
This line predates the migration and was meant as anisotropic texture filtering (hence 16) but was set on the material, where it was a dead property until three added MeshPhysicalMaterial.anisotropy (the KHR anisotropic reflection effect). At r185 it compiled USE_ANISOTROPY into every cloned physical material; the anisotropic GGX term derives its tangent frame from uvs, so any mesh without a uv attribute (33 in the lobby alone) produced NaN specular and rendered as a black void whose silhouette shifted with the viewpoint.